### PR TITLE
Use clippy to eliminate all non idiomatic Rust code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ addons:
       - libdw-dev
 
 # run builds for all the trains (and more)
-rust:
-  - beta
-  # check it compiles on the latest stable compiler
-  - stable
-  # and the previous stable
-  - 1.5.0
+matrix:
+  include:
+    - rust: nightly
+      env: TRAVIS_CARGO_NIGHTLY_FEATURE=nightly
+    - rust: beta
+    - rust: stable
 
 # load travis-cargo
 before_script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ rustc-serialize = "0.3"
 log = "0.3"
 env_logger = "0.3.1"
 num = "0.1"
+clippy = {version = "*", optional = true}
+
+[features]
+default=[]
+nightly = ["clippy"]

--- a/src/conditions.rs
+++ b/src/conditions.rs
@@ -181,7 +181,7 @@ mod test {
         let conditions = from_str(json);
         println!("{:?}", &conditions);
         let conditions: Conditions = conditions.expect("Failed to deserialize a Conditions \
-                                                             struct with only a timeout field");
+                                                        struct with only a timeout field");
         assert_eq!(conditions.timeout, Duration::from_millis(100));
     }
 

--- a/src/conditions.rs
+++ b/src/conditions.rs
@@ -129,8 +129,8 @@ mod test {
     #[test]
     fn test_given_condition_when_an_opening_message_is_received_then_the_state_becomes_opened() {
         let timeout = Duration::from_millis(100);
-        let msg_id1 = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_string();
-        let msg_id2 = "21eaf6f8-0640-460f-aee2-a72d2f2ab258".to_string();
+        let msg_id1 = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_owned();
+        let msg_id2 = "21eaf6f8-0640-460f-aee2-a72d2f2ab258".to_owned();
         let patterns = vec![
             msg_id1.clone(),
         ];
@@ -148,8 +148,8 @@ mod test {
     fn test_given_condition_when_a_closing_message_is_received_then_the_state_becomes_closed() {
         let mut responder = MockResponseSender::new();
         let timeout = Duration::from_millis(100);
-        let msg_id1 = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_string();
-        let msg_id2 = "21eaf6f8-0640-460f-aee2-a72d2f2ab258".to_string();
+        let msg_id1 = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_owned();
+        let msg_id2 = "21eaf6f8-0640-460f-aee2-a72d2f2ab258".to_owned();
         let patterns = vec![
             msg_id1.clone(),
             msg_id2.clone(),
@@ -180,7 +180,7 @@ mod test {
 
         let conditions = from_str(json);
         println!("{:?}", &conditions);
-        let conditions: Conditions = conditions.ok().expect("Failed to deserialize a Conditions \
+        let conditions: Conditions = conditions.expect("Failed to deserialize a Conditions \
                                                              struct with only a timeout field");
         assert_eq!(conditions.timeout, Duration::from_millis(100));
     }
@@ -203,14 +203,13 @@ mod test {
         "#;
 
         let expected_patterns = vec![
-                "1f78c9f1-cd33-4f83-bbcd-9d59f73094d5".to_string(),
-                "2f78c9f1-cd33-4f83-bbcd-9d59f73094d5".to_string(),
-                "PATTERN_NAME".to_string(),
+                "1f78c9f1-cd33-4f83-bbcd-9d59f73094d5".to_owned(),
+                "2f78c9f1-cd33-4f83-bbcd-9d59f73094d5".to_owned(),
+                "PATTERN_NAME".to_owned(),
         ];
         let conditions = from_str(json);
         println!("{:?}", &conditions);
-        let conditions: Conditions = conditions.ok()
-                                               .expect("Failed to deserialize a Conditions struct");
+        let conditions: Conditions = conditions.expect("Failed to deserialize a Conditions struct");
         assert_eq!(conditions.timeout, Duration::from_millis(100));
         assert_eq!(conditions.renew_timeout, Some(Duration::from_millis(50)));
         assert_eq!(conditions.first_opens, true);
@@ -222,7 +221,7 @@ mod test {
     #[test]
     fn test_given_condition_when_there_are_no_patterns_then_any_message_can_open_the_context() {
         let timeout = Duration::from_millis(100);
-        let msg_id = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_string();
+        let msg_id = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_owned();
         let condition = ConditionsBuilder::new(timeout).build();
         let msg = MessageBuilder::new(&msg_id, "message").build();
         assert_true!(condition.is_opening(&msg));
@@ -233,12 +232,12 @@ mod test {
         () {
         let timeout = Duration::from_millis(100);
         let patterns = vec![
-                "p1".to_string(),
-                "p2".to_string(),
-                "p3".to_string(),
+                "p1".to_owned(),
+                "p2".to_owned(),
+                "p3".to_owned(),
         ];
-        let uuid = "e4f3f8b2-3135-4916-a5ea-621a754dab0d".to_string();
-        let msg_id = "p1".to_string();
+        let uuid = "e4f3f8b2-3135-4916-a5ea-621a754dab0d".to_owned();
+        let msg_id = "p1".to_owned();
         let condition = ConditionsBuilder::new(timeout)
                             .patterns(patterns)
                             .first_opens(true)
@@ -252,11 +251,11 @@ mod test {
         () {
         let mut responder = MockResponseSender::new();
         let timeout = Duration::from_millis(100);
-        let patterns = vec!["p1".to_string(), "p2".to_string()];
-        let p1_uuid = "e4f3f8b2-3135-4916-a5ea-621a754dab0d".to_string();
-        let p2_uuid = "f4f3f8b2-3135-4916-a5ea-621a754dab0d".to_string();
-        let p1 = "p1".to_string();
-        let p2 = "p2".to_string();
+        let patterns = vec!["p1".to_owned(), "p2".to_owned()];
+        let p1_uuid = "e4f3f8b2-3135-4916-a5ea-621a754dab0d".to_owned();
+        let p2_uuid = "f4f3f8b2-3135-4916-a5ea-621a754dab0d".to_owned();
+        let p1 = "p1".to_owned();
+        let p2 = "p2".to_owned();
         let mut state = State::new();
         let conditions = ConditionsBuilder::new(timeout)
                              .patterns(patterns)

--- a/src/conditions.rs
+++ b/src/conditions.rs
@@ -347,7 +347,7 @@ mod deser {
                         "last_closes" => Ok(Field::LastCloses),
                         "max_size" => Ok(Field::MaxSize),
                         "patterns" => Ok(Field::Patterns),
-                        name @ _ => Err(Error::syntax(&format!("Unexpected field: {}", name))),
+                        _ => Err(Error::syntax(&format!("Unexpected field: {}", value))),
                     }
                 }
             }
@@ -397,7 +397,7 @@ mod deser {
                 first_opens: first_opens,
                 last_closes: last_closes,
                 max_size: max_size,
-                patterns: patterns.unwrap_or(Vec::new()),
+                patterns: patterns.unwrap_or_default(),
             })
         }
     }

--- a/src/config/action/deser/test.rs
+++ b/src/config/action/deser/test.rs
@@ -13,7 +13,7 @@ fn test_given_action_when_it_is_deserialized_then_we_get_the_right_result() {
     "#;
 
     let result = from_str::<ActionType>(text);
-    let action = result.ok().expect("Failed to deserialize a valid ActionType");
+    let action = result.expect("Failed to deserialize a valid ActionType");
     match action {
         ActionType::Message(message) => {
             assert_eq!("uuid1", message.uuid());
@@ -44,7 +44,7 @@ fn test_given_filled_exec_condition_when_it_is_deserialized_then_it_is_populated
     };
     let result = from_str::<ExecCondition>(text);
     println!("{:?}", &result);
-    let cond = result.ok().expect("Failed to deserialize a valid ExecCondition");
+    let cond = result.expect("Failed to deserialize a valid ExecCondition");
     assert_eq!(expected, cond);
 }
 
@@ -67,6 +67,6 @@ fn test_given_filled_exec_condition_when_it_is_deserialized_then_its_missing_fie
     let expected: ExecCondition = Default::default();
     let result = from_str::<ExecCondition>(text);
     println!("{:?}", &result);
-    let cond = result.ok().expect("Failed to deserialize a valid ExecCondition");
+    let cond = result.expect("Failed to deserialize a valid ExecCondition");
     assert_eq!(expected, cond);
 }

--- a/src/config/action/message/deser.rs
+++ b/src/config/action/message/deser.rs
@@ -56,16 +56,16 @@ impl Deserialize for Field {
 struct MessageActionVisitor;
 
 impl MessageActionVisitor {
-    fn compile_template<V>(template_string: String, uuid: &String) -> Result<Template, V::Error>
+    fn compile_template<V>(template_string: String, uuid: &str) -> Result<Template, V::Error>
         where V: MapVisitor
     {
         match Template::compile(template_string) {
             Ok(message) => Ok(message),
             Err(error) => {
-                return Err(Error::syntax(&format!("Invalid handlebars template in 'message' \
+                Err(Error::syntax(&format!("Invalid handlebars template in 'message' \
                                                    field: uuid={}, error={}",
-                                                  &uuid,
-                                                  error)));
+                                                  uuid,
+                                                  error)))
             }
         }
     }

--- a/src/config/action/message/deser.rs
+++ b/src/config/action/message/deser.rs
@@ -188,14 +188,11 @@ mod test {
         }
         "#;
 
-        let message = Template::compile("message".to_string())
-                          .ok()
+        let message = Template::compile("message".to_owned())
                           .expect("Failed to compile a handlebars template");
-        let value1 = Template::compile("value1".to_string())
-                         .ok()
+        let value1 = Template::compile("value1".to_owned())
                          .expect("Failed to compile a handlebars template");
-        let value2 = Template::compile("value2".to_string())
-                         .ok()
+        let value2 = Template::compile("value2".to_owned())
                          .expect("Failed to compile a handlebars template");
         let expected_message = MessageActionBuilder::new("UUID", message)
                                    .name(Some("NAME"))
@@ -203,7 +200,7 @@ mod test {
                                    .pair("key2", value2)
                                    .build();
         let result = from_str::<MessageAction>(text);
-        let message = result.ok().expect("Failed to deserialize a valid MessageAction object");
+        let message = result.expect("Failed to deserialize a valid MessageAction object");
         assert_message_action_eq(&expected_message, &message);
     }
 
@@ -217,12 +214,11 @@ mod test {
         }
         "#;
 
-        let message = Template::compile("message".to_string())
-                          .ok()
+        let message = Template::compile("message".to_owned())
                           .expect("Failed to compile a handlebars template");
         let expected_message = MessageActionBuilder::new("UUID", message).build();
         let result = from_str::<MessageAction>(text);
-        let message = result.ok().expect("Failed to deserialize a valid MessageAction object");
+        let message = result.expect("Failed to deserialize a valid MessageAction object");
         assert_message_action_eq(&expected_message, &message);
     }
 
@@ -250,7 +246,7 @@ mod test {
 
         let result = from_str::<Vec<InjectMode>>(text);
         println!("{:?}", &result);
-        let array = result.ok().expect("Failed to deserialize a valid array of inject modes");
+        let array = result.expect("Failed to deserialize a valid array of inject modes");
         assert_eq!(&expected, &array);
     }
 
@@ -275,14 +271,13 @@ mod test {
         }
         "#;
 
-        let message = Template::compile("message".to_string())
-                          .ok()
+        let message = Template::compile("message".to_owned())
                           .expect("Failed to compile a handlebars template");
         let expected_message = MessageActionBuilder::new("UUID", message)
                                    .inject_mode(InjectMode::Forward)
                                    .build();
         let result = from_str::<MessageAction>(text);
-        let message = result.ok().expect("Failed to deserialize a valid MessageAction object");
+        let message = result.expect("Failed to deserialize a valid MessageAction object");
         assert_message_action_eq(&expected_message, &message);
     }
 }

--- a/src/config/action/message/deser.rs
+++ b/src/config/action/message/deser.rs
@@ -62,10 +62,10 @@ impl MessageActionVisitor {
         match Template::compile(template_string) {
             Ok(message) => Ok(message),
             Err(error) => {
-                Err(Error::syntax(&format!("Invalid handlebars template in 'message' \
-                                                   field: uuid={}, error={}",
-                                                  uuid,
-                                                  error)))
+                Err(Error::syntax(&format!("Invalid handlebars template in 'message' field: \
+                                            uuid={}, error={}",
+                                           uuid,
+                                           error)))
             }
         }
     }

--- a/src/config/action/message/mod.rs
+++ b/src/config/action/message/mod.rs
@@ -25,8 +25,6 @@ const MESSAGE: &'static str = "MESSAGE";
 use handlebars::Template;
 use handlebars::Handlebars;
 
-
-use super::ActionType;
 use super::ExecCondition;
 
 mod deser;
@@ -60,7 +58,7 @@ impl MessageAction {
         &self.inject_mode
     }
 
-    fn render_value(&self, key: &String, template_context: &Context) -> Result<String, Error> {
+    fn render_value(&self, key: &str, template_context: &Context) -> Result<String, Error> {
         let mut writer = Vec::new();
         {
             try!(self.values.renderw(key, &template_context, &mut writer));
@@ -73,7 +71,7 @@ impl MessageAction {
         let mut rendered_values = BTreeMap::new();
         for (key, _) in self.values.get_templates() {
             let rendered_value = try!(self.render_value(key, &template_context));
-            rendered_values.insert(key.to_string(), rendered_value);
+            rendered_values.insert(key.to_owned(), rendered_value);
         }
         Ok(rendered_values)
     }
@@ -102,16 +100,16 @@ impl MessageAction {
     fn extend_with_context_information(values: &mut BTreeMap<String, String>,
                                        state: &State,
                                        context: &BaseContext) {
-        values.insert(CONTEXT_UUID.to_string(),
+        values.insert(CONTEXT_UUID.to_owned(),
                       context.uuid().to_hyphenated_string());
-        values.insert(CONTEXT_LEN.to_string(), state.messages().len().to_string());
+        values.insert(CONTEXT_LEN.to_owned(), state.messages().len().to_string());
         if let Some(name) = context.name() {
-            values.insert(CONTEXT_NAME.to_string(), name.to_string());
+            values.insert(CONTEXT_NAME.to_owned(), name.to_owned());
         }
     }
 
-    fn execute(&self, _state: &State, _context: &BaseContext, responder: &mut ResponseSender) {
-        match self.render_message(_state, _context) {
+    fn execute(&self, state: &State, context: &BaseContext, responder: &mut ResponseSender) {
+        match self.render_message(state, context) {
             Ok(message) => {
                 let response = Alert {
                     message: message,
@@ -158,17 +156,17 @@ impl Alert {
 }
 
 impl Action for MessageAction {
-    fn on_opened(&self, _state: &State, _context: &BaseContext, responder: &mut ResponseSender) {
+    fn on_opened(&self, state: &State, context: &BaseContext, responder: &mut ResponseSender) {
         if self.when.on_opened {
             trace!("MessageAction: on_opened()");
-            self.execute(_state, _context, responder);
+            self.execute(state, context, responder);
         }
     }
 
-    fn on_closed(&self, _state: &State, _context: &BaseContext, responder: &mut ResponseSender) {
+    fn on_closed(&self, state: &State, context: &BaseContext, responder: &mut ResponseSender) {
         if self.when.on_closed {
             trace!("MessageAction: on_closed()");
-            self.execute(_state, _context, responder);
+            self.execute(state, context, responder);
         }
     }
 }

--- a/src/config/action/message/renderer_context.rs
+++ b/src/config/action/message/renderer_context.rs
@@ -16,7 +16,7 @@ pub struct RendererContext<'m, 'c> {
 }
 
 impl<'m, 'c> RendererContext<'m, 'c> {
-    pub fn new<'a>(state: &'m State, context: &'c BaseContext) -> RendererContext<'m, 'c> {
+    pub fn new(state: &'m State, context: &'c BaseContext) -> RendererContext<'m, 'c> {
         RendererContext {
             messages: state.messages(),
             context_name: context.name(),
@@ -29,12 +29,12 @@ impl<'m, 'c> ToJson for RendererContext<'m, 'c> {
     fn to_json(&self) -> Json {
         let mut m: BTreeMap<String, Json> = BTreeMap::new();
         if let Some(name) = self.context_name {
-            m.insert(CONTEXT_NAME.to_string(), name.to_json());
+            m.insert(CONTEXT_NAME.to_owned(), name.to_json());
         }
-        m.insert(CONTEXT_UUID.to_string(),
+        m.insert(CONTEXT_UUID.to_owned(),
                  self.context_uuid.to_hyphenated_string().to_json());
-        m.insert(CONTEXT_LEN.to_string(), self.messages.len().to_json());
-        m.insert(MESSAGES.to_string(), rc_message_to_json(self.messages));
+        m.insert(CONTEXT_LEN.to_owned(), self.messages.len().to_json());
+        m.insert(MESSAGES.to_owned(), rc_message_to_json(self.messages));
         m.to_json()
     }
 }

--- a/src/config/deser.rs
+++ b/src/config/deser.rs
@@ -60,16 +60,14 @@ impl ContextVisitor {
                 match Uuid::parse_str(&value) {
                     Ok(uuid) => Ok(uuid),
                     Err(err) => {
-                        Err(Error::syntax(&format!("Failed to parse field 'uuid': \
-                                                           uuid={} error={}",
-                                                          value,
-                                                          err)))
+                        Err(Error::syntax(&format!("Failed to parse field 'uuid': uuid={} \
+                                                    error={}",
+                                                   value,
+                                                   err)))
                     }
                 }
             }
-            None => {
-                Err(Error::missing_field("uuid"))
-            }
+            None => Err(Error::missing_field("uuid")),
         }
     }
 

--- a/src/config/deser.rs
+++ b/src/config/deser.rs
@@ -181,17 +181,16 @@ mod test {
         "#;
 
         let result = from_str::<ContextConfig>(text);
-        let expected_name = "TEST_NAME".to_string();
+        let expected_name = "TEST_NAME".to_owned();
         let expected_uuid = Uuid::parse_str("86ca9f93-84fb-4813-b037-6526f7a585a3").ok().unwrap();
         let expected_conditions = ConditionsBuilder::new(Duration::from_millis(100))
                                       .first_opens(true)
-                                      .patterns(vec!["PATTERN_NAME1".to_string(),
-                                                     "PATTERN_NAME2".to_string(),
+                                      .patterns(vec!["PATTERN_NAME1".to_owned(),
+                                                     "PATTERN_NAME2".to_owned(),
                                                      "f13dafee-cd14-4dda-995c-6ed476a21de3"
-                                                         .to_string()])
+                                                         .to_owned()])
                                       .build();
-        let message = Template::compile("message".to_string())
-                          .ok()
+        let message = Template::compile("message".to_owned())
                           .expect("Failed to compile a handlebars template");
         let expected_exec_cond = ExecCondition {
             on_opened: false,
@@ -201,7 +200,7 @@ mod test {
                                                                                   message)
                                                             .when(expected_exec_cond)
                                                             .build())];
-        let context = result.ok().expect("Failed to deserialize a valid ContextConfig");
+        let context = result.expect("Failed to deserialize a valid ContextConfig");
         assert_eq!(&Some(expected_name), &context.name);
         assert_eq!(&expected_uuid, &context.uuid);
         assert_eq!(&expected_conditions, &context.conditions);
@@ -243,7 +242,7 @@ mod test {
         let result = from_str::<ContextConfig>(text);
         let expected_uuid = Uuid::parse_str("86ca9f93-84fb-4813-b037-6526f7a585a3").ok().unwrap();
         let expected_conditions = ConditionsBuilder::new(Duration::from_millis(100)).build();
-        let context = result.ok().expect("Failed to deserialize a valid ContextConfig");
+        let context = result.expect("Failed to deserialize a valid ContextConfig");
         assert_eq!(&expected_uuid, &context.uuid);
         assert_eq!(&expected_conditions, &context.conditions);
     }
@@ -277,9 +276,9 @@ mod test {
             }
         }
         "#;
-        let expected_context_id = "{{HOST}}{{PROGRAM}}".to_string();
+        let expected_context_id = "{{HOST}}{{PROGRAM}}".to_owned();
         let result = from_str::<ContextConfig>(text);
-        let context = result.ok().expect("Failed to deserialize a valid ContextConfig");
+        let context = result.expect("Failed to deserialize a valid ContextConfig");
         assert_eq!(&expected_context_id,
                    &context.context_id.as_ref().unwrap().to_string());
     }

--- a/src/config/deser.rs
+++ b/src/config/deser.rs
@@ -60,15 +60,15 @@ impl ContextVisitor {
                 match Uuid::parse_str(&value) {
                     Ok(uuid) => Ok(uuid),
                     Err(err) => {
-                        return Err(Error::syntax(&format!("Failed to parse field 'uuid': \
+                        Err(Error::syntax(&format!("Failed to parse field 'uuid': \
                                                            uuid={} error={}",
                                                           value,
-                                                          err)));
+                                                          err)))
                     }
                 }
             }
             None => {
-                return Err(Error::missing_field("uuid"));
+                Err(Error::missing_field("uuid"))
             }
         }
     }
@@ -95,7 +95,7 @@ impl ContextVisitor {
                                       error={}",
                                      uuid,
                                      err);
-                return Err(Error::syntax(&errmsg));
+                Err(Error::syntax(&errmsg))
             }
         }
     }
@@ -125,7 +125,7 @@ impl Visitor for ContextVisitor {
 
         let uuid = try!(ContextVisitor::parse_uuid::<V>(uuid));
         let context_id = try!(ContextVisitor::deser_context_id::<V>(context_id, &uuid));
-        let actions = actions.unwrap_or(Vec::new());
+        let actions = actions.unwrap_or_default();
 
         try!(visitor.end());
 

--- a/src/context/context_map.rs
+++ b/src/context/context_map.rs
@@ -108,10 +108,10 @@ mod tests {
     use uuid::Uuid;
     use std::time::Duration;
 
-    fn assert_conext_map_contains_uuid(context_map: &mut ContextMap, uuid: &Uuid, key: &String) {
+    fn assert_context_map_contains_uuid(context_map: &mut ContextMap, uuid: &Uuid, key: &str) {
         let mut iter = context_map.contexts_iter_mut(key);
         let context = iter.next().expect("Failed to get back an inserted context");
-        if let &mut Context::Linear(ref context) = context {
+        if let Context::Linear(ref context) = *context {
             assert_eq!(uuid, context.uuid());
         } else {
             unreachable!();
@@ -125,7 +125,7 @@ mod tests {
         let uuid = Uuid::new_v4();
         let context1 = {
             let conditions = {
-                let patterns = vec!["A".to_string(), "B".to_string()];
+                let patterns = vec!["A".to_owned(), "B".to_owned()];
                 ConditionsBuilder::new(Duration::from_millis(100)).patterns(patterns).build()
             };
             let base = BaseContextBuilder::new(uuid.clone(), conditions).build();
@@ -133,7 +133,7 @@ mod tests {
         };
         context_map.insert(Context::Linear(context1));
         assert_eq!(context_map.contexts_mut().len(), 1);
-        assert_conext_map_contains_uuid(&mut context_map, &uuid, &"A".to_string());
-        assert_conext_map_contains_uuid(&mut context_map, &uuid, &"B".to_string());
+        assert_context_map_contains_uuid(&mut context_map, &uuid, "A");
+        assert_context_map_contains_uuid(&mut context_map, &uuid, "B");
     }
 }

--- a/src/context/context_map.rs
+++ b/src/context/context_map.rs
@@ -74,7 +74,7 @@ impl ContextMap {
 
 pub trait StreamingIterator {
     type Item;
-    fn next<'a>(&'a mut self) -> Option<&'a mut Self::Item>;
+    fn next(&mut self) -> Option<&mut Self::Item>;
 }
 
 pub struct Iterator<'a> {

--- a/src/context/context_map.rs
+++ b/src/context/context_map.rs
@@ -54,7 +54,7 @@ impl ContextMap {
                                             new_index: usize,
                                             patterns: &[String]) {
         for i in patterns {
-            map.entry(i.clone()).or_insert(Vec::new()).push(new_index);
+            map.entry(i.clone()).or_insert_with(Vec::new).push(new_index);
         }
     }
 
@@ -62,7 +62,7 @@ impl ContextMap {
         &mut self.contexts
     }
 
-    pub fn contexts_iter_mut(&mut self, key: &String) -> Iterator {
+    pub fn contexts_iter_mut(&mut self, key: &str) -> Iterator {
         let ids = self.map.get(key);
         Iterator {
             ids: ids,

--- a/src/context/map/map.rs
+++ b/src/context/map/map.rs
@@ -73,7 +73,8 @@ impl MapContext {
             let state = self.map.entry(id).or_insert_with(State::new);
             state.on_message(event, &self.base, responder);
         } else {
-            error!("Failed to render the context-id: {:?}", self.context_id.get_template(&CONTEXT_ID.to_owned()));
+            error!("Failed to render the context-id: {:?}",
+                   self.context_id.get_template(&CONTEXT_ID.to_owned()));
         }
     }
 

--- a/src/context/map/map.rs
+++ b/src/context/map/map.rs
@@ -38,7 +38,7 @@ impl MapContext {
     }
 
     pub fn on_timer(&mut self, event: &TimerEvent, responder: &mut ResponseSender) {
-        for (_, mut state) in self.map.iter_mut() {
+        for (_, mut state) in &mut self.map {
             state.on_timer(event, &self.base, responder);
         }
         self.remove_closed_states();
@@ -69,16 +69,16 @@ impl MapContext {
     }
 
     fn update_state(&mut self, event: Arc<Message>, responder: &mut ResponseSender) {
-        let id = self.context_id
-                     .render(CONTEXT_ID, event.values())
-                     .ok()
-                     .expect("Failed to render the compiled Handlebars template");
-        let state = self.map.entry(id).or_insert(State::new());
-        state.on_message(event, &self.base, responder);
+        if let Ok(id) = self.context_id.render(CONTEXT_ID, event.values()) {
+            let state = self.map.entry(id).or_insert_with(State::new);
+            state.on_message(event, &self.base, responder);
+        } else {
+            error!("Failed to render the context-id: {:?}", self.context_id.get_template(&CONTEXT_ID.to_owned()));
+        }
     }
 
     #[allow(dead_code)]
-    pub fn is_open(&mut self) -> bool {
+    pub fn is_open(&self) -> bool {
         !self.map.is_empty()
     }
 

--- a/src/context/map/test.rs
+++ b/src/context/map/test.rs
@@ -15,9 +15,9 @@ fn test_given_map_context_when_messages_have_the_same_kvpairs_then_they_go_to_th
     let delta = Duration::from_millis(10);
     let timeout = Duration::from_millis(30);
     let event = TimerEvent(delta);
-    let msg_id1 = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_string();
-    let msg_id2 = "21eaf6f8-0640-460f-aee2-a72d2f2ab258".to_string();
-    let msg_id3 = "31eaf6f8-0640-460f-aee2-a72d2f2ab258".to_string();
+    let msg_id1 = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_owned();
+    let msg_id2 = "21eaf6f8-0640-460f-aee2-a72d2f2ab258".to_owned();
+    let msg_id3 = "31eaf6f8-0640-460f-aee2-a72d2f2ab258".to_owned();
     let mut context = {
         let base_context = {
             let patterns = vec![
@@ -29,7 +29,7 @@ fn test_given_map_context_when_messages_have_the_same_kvpairs_then_they_go_to_th
             let conditions = ConditionsBuilder::new(timeout).patterns(patterns).build();
             BaseContextBuilder::new(uuid, conditions).build()
         };
-        let context_id = Template::compile("{{HOST}}{{PROGRAM}}{{PID}}".to_string()).unwrap();
+        let context_id = Template::compile("{{HOST}}{{PROGRAM}}{{PID}}".to_owned()).unwrap();
         MapContext::new(base_context, context_id)
     };
     let msg1 = MessageBuilder::new(&msg_id1, "message")

--- a/src/context/test.rs
+++ b/src/context/test.rs
@@ -13,7 +13,7 @@ use dispatcher::response::MockResponseSender;
 fn test_given_close_condition_with_timeout_when_the_timeout_expires_then_the_condition_is_met() {
     let mut responder = MockResponseSender::new();
     let timeout = Duration::from_millis(100);
-    let msg_id = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_string();
+    let msg_id = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_owned();
     let patterns = vec![
         msg_id.clone(),
     ];
@@ -27,11 +27,11 @@ fn test_given_close_condition_with_timeout_when_the_timeout_expires_then_the_con
     assert_false!(context.is_open());
     context.on_message(event, &mut responder);
     assert_true!(context.is_open());
-    context.on_timer(&mut TimerEvent::from_millis(50), &mut responder);
+    context.on_timer(&TimerEvent::from_millis(50), &mut responder);
     assert_true!(context.is_open());
-    context.on_timer(&mut TimerEvent::from_millis(49), &mut responder);
+    context.on_timer(&TimerEvent::from_millis(49), &mut responder);
     assert_true!(context.is_open());
-    context.on_timer(&mut TimerEvent::from_millis(1), &mut responder);
+    context.on_timer(&TimerEvent::from_millis(1), &mut responder);
     assert_false!(context.is_open());
 }
 
@@ -41,7 +41,7 @@ fn test_given_close_condition_with_max_size_when_the_max_size_reached_then_the_c
     let mut responder = MockResponseSender::new();
     let timeout = Duration::from_millis(100);
     let max_size = 3;
-    let msg_id = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_string();
+    let msg_id = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_owned();
     let patterns = vec![
         msg_id.clone(),
     ];
@@ -67,7 +67,7 @@ fn test_given_close_condition_with_renew_timeout_when_the_timeout_expires_withou
     let mut responder = MockResponseSender::new();
     let timeout = Duration::from_millis(100);
     let renew_timeout = Duration::from_millis(10);
-    let msg_id = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_string();
+    let msg_id = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_owned();
     let patterns = vec![
         msg_id.clone(),
     ];
@@ -81,11 +81,11 @@ fn test_given_close_condition_with_renew_timeout_when_the_timeout_expires_withou
     let event = Arc::new(msg1);
     context.on_message(event.clone(), &mut responder);
     assert_true!(context.is_open());
-    context.on_timer(&mut TimerEvent::from_millis(8), &mut responder);
+    context.on_timer(&TimerEvent::from_millis(8), &mut responder);
     assert_true!(context.is_open());
-    context.on_timer(&mut TimerEvent::from_millis(1), &mut responder);
+    context.on_timer(&TimerEvent::from_millis(1), &mut responder);
     assert_true!(context.is_open());
-    context.on_timer(&mut TimerEvent::from_millis(1), &mut responder);
+    context.on_timer(&TimerEvent::from_millis(1), &mut responder);
     assert_false!(context.is_open());
 }
 
@@ -95,7 +95,7 @@ fn test_given_close_condition_with_renew_timeout_when_the_timeout_expires_with_r
     let mut responder = MockResponseSender::new();
     let timeout = Duration::from_millis(100);
     let renew_timeout = Duration::from_millis(10);
-    let msg_id = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_string();
+    let msg_id = "11eaf6f8-0640-460f-aee2-a72d2f2ab258".to_owned();
     let patterns = vec![
         msg_id.clone(),
     ];
@@ -110,12 +110,12 @@ fn test_given_close_condition_with_renew_timeout_when_the_timeout_expires_with_r
     assert_false!(context.is_open());
     context.on_message(event.clone(), &mut responder);
     assert_true!(context.is_open());
-    context.on_timer(&mut TimerEvent::from_millis(8), &mut responder);
+    context.on_timer(&TimerEvent::from_millis(8), &mut responder);
     assert_true!(context.is_open());
-    context.on_timer(&mut TimerEvent::from_millis(1), &mut responder);
+    context.on_timer(&TimerEvent::from_millis(1), &mut responder);
     assert_true!(context.is_open());
     context.on_message(event.clone(), &mut responder);
     assert_true!(context.is_open());
-    context.on_timer(&mut TimerEvent::from_millis(1), &mut responder);
+    context.on_timer(&TimerEvent::from_millis(1), &mut responder);
     assert_true!(context.is_open());
 }

--- a/src/correlator/mod.rs
+++ b/src/correlator/mod.rs
@@ -53,7 +53,7 @@ impl Correlator {
         let context_map = ContextMap::from_configs(contexts);
         let (dispatcher_input_channel, rx) = mpsc::channel();
         let (dispatcher_output_channel_tx, dispatcher_output_channel_rx) = mpsc::channel();
-        let _ = Timer::from_chan(Duration::from_millis(TIMER_STEP_MS),
+        Timer::from_chan(Duration::from_millis(TIMER_STEP_MS),
                                  dispatcher_input_channel.clone());
 
         let handle = thread::spawn(move || {

--- a/src/correlator/mod.rs
+++ b/src/correlator/mod.rs
@@ -54,7 +54,7 @@ impl Correlator {
         let (dispatcher_input_channel, rx) = mpsc::channel();
         let (dispatcher_output_channel_tx, dispatcher_output_channel_rx) = mpsc::channel();
         Timer::from_chan(Duration::from_millis(TIMER_STEP_MS),
-                                 dispatcher_input_channel.clone());
+                         dispatcher_input_channel.clone());
 
         let handle = thread::spawn(move || {
             let dmux = Demultiplexer::new(rx);

--- a/src/correlator/test.rs
+++ b/src/correlator/test.rs
@@ -87,9 +87,9 @@ const JSON_CONFIG: &'static str = r#"
 
 #[test]
 fn test_given_manually_built_correlator_when_it_closes_a_context_then_the_actions_are_executed() {
-    let uuid1 = "1b47ba91-d867-4a8c-9553-a5dfd6ea1274".to_string();
-    let uuid2 = "2b47ba91-d867-4a8c-9553-a5dfd6ea1274".to_string();
-    let uuid3 = "3b47ba91-d867-4a8c-9553-a5dfd6ea1274".to_string();
+    let uuid1 = "1b47ba91-d867-4a8c-9553-a5dfd6ea1274".to_owned();
+    let uuid2 = "2b47ba91-d867-4a8c-9553-a5dfd6ea1274".to_owned();
+    let uuid3 = "3b47ba91-d867-4a8c-9553-a5dfd6ea1274".to_owned();
     let patterns = vec![
         uuid1.clone(),
         uuid2.clone(),
@@ -100,8 +100,7 @@ fn test_given_manually_built_correlator_when_it_closes_a_context_then_the_action
                         .first_opens(true)
                         .last_closes(true)
                         .build();
-    let message = Template::compile("message".to_string())
-                      .ok()
+    let message = Template::compile("message".to_owned())
                       .expect("Failed to compile a handlebars template");
     let contexts = vec![
         ContextConfigBuilder::new(Uuid::new_v4(), condition.clone()).actions(vec![MessageActionBuilder::new("uuid", message.clone()).build().into()]).build(),
@@ -124,10 +123,9 @@ fn test_given_manually_built_correlator_when_it_closes_a_context_then_the_action
 #[test]
 fn test_given_correlator_when_it_is_built_from_json_then_we_get_the_expected_correlator() {
     let result = from_str::<Vec<ContextConfig>>(JSON_CONFIG);
-    let expected_name = "CONTEXT_NAME_1".to_string();
-    let expected_uuid = "185e96da-c00e-454b-b4fe-9d0a14a86335".to_string();
-    let mut contexts = result.ok()
-                             .expect("Failed to deserialize a config::ContextConfig from JSON");
+    let expected_name = "CONTEXT_NAME_1".to_owned();
+    let expected_uuid = "185e96da-c00e-454b-b4fe-9d0a14a86335".to_owned();
+    let mut contexts = result.expect("Failed to deserialize a config::ContextConfig from JSON");
     for i in &contexts {
         assert_eq!(true, i.name.is_some());
     }
@@ -139,11 +137,11 @@ fn test_given_correlator_when_it_is_built_from_json_then_we_get_the_expected_cor
 #[test]
 fn test_given_correlator_when_it_is_built_from_json_then_it_produces_the_expected_number_of_messages
     () {
-    let uuid1 = "1b47ba91-d867-4a8c-9553-a5dfd6ea1274".to_string();
-    let uuid2 = "2b47ba91-d867-4a8c-9553-a5dfd6ea1274".to_string();
-    let uuid3 = "3b47ba91-d867-4a8c-9553-a5dfd6ea1274".to_string();
+    let uuid1 = "1b47ba91-d867-4a8c-9553-a5dfd6ea1274".to_owned();
+    let uuid2 = "2b47ba91-d867-4a8c-9553-a5dfd6ea1274".to_owned();
+    let uuid3 = "3b47ba91-d867-4a8c-9553-a5dfd6ea1274".to_owned();
     let result = from_str::<Vec<ContextConfig>>(JSON_CONFIG);
-    let contexts = result.ok().expect("Failed to deserialize a config::ContextConfig from JSON");
+    let contexts = result.expect("Failed to deserialize a config::ContextConfig from JSON");
     let responses = Rc::new(RefCell::new(Vec::new()));
     let message_event_handler = Box::new(MessageEventHandler { responses: responses.clone() });
     let mut correlator = Correlator::new(contexts);

--- a/src/dispatcher/reactor.rs
+++ b/src/dispatcher/reactor.rs
@@ -6,6 +6,7 @@ use dispatcher::request::{RequestHandle, Request};
 use reactor::{Event, EventDemultiplexer, EventHandler, Reactor, SharedData};
 use dispatcher::response::ResponseSender;
 
+#[allow(type_complexity)]
 pub struct RequestReactor {
     handlers: BTreeMap<RequestHandle, Box<for<'a> EventHandler<Request, SharedData<'a>>>>,
     demultiplexer: Demultiplexer<Request>,

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -50,8 +50,7 @@ mod tests {
     fn test_given_valid_duration_when_it_is_deserialized_then_we_get_the_right_result() {
         let result = serde_json::from_str::<SerializableDuration>("100");
         println!("{:?}", &result);
-        let duration = result.ok()
-                             .expect("Failed to deserialize a valid SerializableDuration value");
+        let duration = result.expect("Failed to deserialize a valid SerializableDuration value");
         assert_eq!(Duration::from_millis(100), duration.0);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(feature="nightly", feature(plugin))]
+#![cfg_attr(feature="nightly", plugin(clippy))]
+#![cfg_attr(feature="nightly", deny(warnings))]
+
 #[macro_use]
 extern crate maplit;
 extern crate env_logger;

--- a/src/message/builder.rs
+++ b/src/message/builder.rs
@@ -12,7 +12,7 @@ pub struct MessageBuilder {
 impl MessageBuilder {
     pub fn new<S: Into<String>>(uuid: &str, message: S) -> MessageBuilder {
         MessageBuilder {
-            uuid: uuid.to_string(),
+            uuid: uuid.to_owned(),
             name: None,
             message: message.into(),
             values: BTreeMap::new(),
@@ -30,7 +30,7 @@ impl MessageBuilder {
     }
 
     pub fn pair(&mut self, key: &str, value: &str) -> &mut MessageBuilder {
-        self.values.insert(key.to_string(), value.to_string());
+        self.values.insert(key.to_owned(), value.to_owned());
         self
     }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -37,7 +37,7 @@ impl Message {
     }
 
     pub fn insert(&mut self, key: &str, value: &str) {
-        self.values.insert(key.to_string(), value.to_string());
+        self.values.insert(key.to_owned(), value.to_owned());
     }
 
     pub fn ids(&self) -> IdIterator {

--- a/src/message/to_json.rs
+++ b/src/message/to_json.rs
@@ -12,10 +12,10 @@ impl<'a> ToJson for &'a Message {
 impl ToJson for Message {
     fn to_json(&self) -> Json {
         let mut m: BTreeMap<String, Json> = BTreeMap::new();
-        m.insert("uuid".to_string(), self.uuid.to_json());
-        m.insert("name".to_string(), self.name.to_json());
-        m.insert("message".to_string(), self.message.to_json());
-        m.insert("values".to_string(), self.values.to_json());
+        m.insert("uuid".to_owned(), self.uuid.to_json());
+        m.insert("name".to_owned(), self.name.to_json());
+        m.insert("message".to_owned(), self.message.to_json());
+        m.insert("values".to_owned(), self.values.to_json());
         m.to_json()
     }
 }


### PR DESCRIPTION
Also, enable nightly builds and enable the 'nightly' feature. It
enables clippy and also turn all warnings to errors (like Werror).

Signed-off-by: Tibor Benke ihrwein@gmail.com
