### PR TITLE
Make Correlator's new() and stop() symmetrical by taking and returning a ContextMap

### DIFF
--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -7,6 +7,7 @@ use correlation::Correlator;
 use correlation::config::ContextConfigBuilder;
 use correlation::conditions::ConditionsBuilder;
 use correlation::message::MessageBuilder;
+use correlation::ContextMap;
 use uuid::Uuid;
 use std::thread;
 use std::time::Duration;
@@ -31,7 +32,7 @@ fn main() {
         ContextConfigBuilder::new(Uuid::new_v4(), condition.clone()).actions(Vec::new()).build(),
         ContextConfigBuilder::new(Uuid::new_v4(), condition.clone()).actions(Vec::new()).build(),
     ];
-    let mut correlator = Correlator::new(contexts);
+    let mut correlator = Correlator::new(ContextMap::from_configs(contexts));
     let _ = correlator.push_message(MessageBuilder::new(&uuid1, "message").build());
     thread::sleep(Duration::from_millis(20));
     let _ = correlator.push_message(MessageBuilder::new(&uuid2, "message").build());

--- a/src/correlator/mod.rs
+++ b/src/correlator/mod.rs
@@ -46,11 +46,10 @@ impl Correlator {
         let contexts = try!(from_str::<Vec<ContextConfig>>(&buffer));
         trace!("Correlator: loading contexts from file; len={}",
                contexts.len());
-        Ok(Correlator::new(contexts))
+        Ok(Correlator::new(ContextMap::from_configs(contexts)))
     }
 
-    pub fn new(contexts: Vec<ContextConfig>) -> Correlator {
-        let context_map = ContextMap::from_configs(contexts);
+    pub fn new(context_map: ContextMap) -> Correlator {
         let (dispatcher_input_channel, rx) = mpsc::channel();
         let (dispatcher_output_channel_tx, dispatcher_output_channel_rx) = mpsc::channel();
         Timer::from_chan(Duration::from_millis(TIMER_STEP_MS),

--- a/src/correlator/mod.rs
+++ b/src/correlator/mod.rs
@@ -34,7 +34,7 @@ mod test;
 pub struct Correlator {
     dispatcher_input_channel: mpsc::Sender<Request>,
     dispatcher_output_channel: mpsc::Receiver<Response>,
-    dispatcher_thread_handle: thread::JoinHandle<()>,
+    dispatcher_thread_handle: thread::JoinHandle<ContextMap>,
     handlers: HashMap<ResponseHandle, Box<EventHandler<Response, mpsc::Sender<Request>>>>,
 }
 
@@ -70,6 +70,7 @@ impl Correlator {
             reactor.register_handler(message_event_handler);
             reactor.handle_events();
             trace!("Correlator: dispatcher thread exited");
+            reactor.context_map
         });
 
         Correlator {
@@ -104,7 +105,7 @@ impl Correlator {
         }
     }
 
-    pub fn stop(mut self) -> thread::Result<()> {
+    pub fn stop(mut self) -> thread::Result<ContextMap> {
         self.handle_events();
         self.stop_dispatcher();
         self.dispatcher_thread_handle.join()

--- a/src/correlator/test.rs
+++ b/src/correlator/test.rs
@@ -2,6 +2,7 @@ use config::{ContextConfigBuilder, ContextConfig};
 use config::action::message::MessageActionBuilder;
 use conditions::ConditionsBuilder;
 use Correlator;
+use context::ContextMap;
 use message::MessageBuilder;
 
 
@@ -109,7 +110,7 @@ fn test_given_manually_built_correlator_when_it_closes_a_context_then_the_action
     ];
     let responses = Rc::new(RefCell::new(Vec::new()));
     let message_event_handler = Box::new(MessageEventHandler { responses: responses.clone() });
-    let mut correlator = Correlator::new(contexts);
+    let mut correlator = Correlator::new(ContextMap::from_configs(contexts));
     correlator.register_handler(message_event_handler);
     let _ = correlator.push_message(MessageBuilder::new(&uuid1, "message").build());
     thread::sleep(Duration::from_millis(20));
@@ -144,7 +145,7 @@ fn test_given_correlator_when_it_is_built_from_json_then_it_produces_the_expecte
     let contexts = result.expect("Failed to deserialize a config::ContextConfig from JSON");
     let responses = Rc::new(RefCell::new(Vec::new()));
     let message_event_handler = Box::new(MessageEventHandler { responses: responses.clone() });
-    let mut correlator = Correlator::new(contexts);
+    let mut correlator = Correlator::new(ContextMap::from_configs(contexts));
     correlator.register_handler(message_event_handler);
     let _ = correlator.push_message(MessageBuilder::new(&uuid1, "message")
                                         .name(Some("p1"))

--- a/src/dispatcher/reactor.rs
+++ b/src/dispatcher/reactor.rs
@@ -10,7 +10,7 @@ use dispatcher::response::ResponseSender;
 pub struct RequestReactor {
     handlers: BTreeMap<RequestHandle, Box<for<'a> EventHandler<Request, SharedData<'a>>>>,
     demultiplexer: Demultiplexer<Request>,
-    context_map: ContextMap,
+    pub context_map: ContextMap,
     responder: Box<ResponseSender>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub use correlator::Correlator;
 pub use config::action::ActionType;
 pub use dispatcher::Response;
 pub use message::Message;
+pub use context::ContextMap;
 
 pub mod conditions;
 pub mod config;


### PR DESCRIPTION
Fixes #17 
